### PR TITLE
Обработка исключений, если запрос на получение вопроса прилетел не туда

### DIFF
--- a/apps/questions/permissions.py
+++ b/apps/questions/permissions.py
@@ -1,0 +1,36 @@
+from rest_framework import permissions
+from rest_framework.exceptions import PermissionDenied
+
+from courses.models import TaskObject
+
+
+class CheckQuestionTypePermission(permissions.BasePermission):
+    """
+    Проверка типа вопроса для GET эндпоинта вопросов, если запрос прилетел не туда,
+    то резится PermissionDenied пояснением, что необходимо было дернуть.
+    """
+
+    def has_permission(self, request, view):
+        task_object_id = view.kwargs.get("task_obj_id")
+        try:
+            request_task_object: TaskObject = TaskObject.objects.prefetch_related(
+                "content_object",
+                "content_object__files",
+            ).get(id=task_object_id)
+
+        except TaskObject.DoesNotExist:
+            raise PermissionDenied({"error": 'You tried to summon taskobject with a wrong id.'})
+        else:
+            request_question = request_task_object.content_object
+            if isinstance(request_question, view.expected_question_model):
+                # Установка атрибутов класса представления, чтобы повторно не дергать БД с запросом.
+                view.task_object_id = task_object_id
+                view.request_question = request_question
+                return True
+            raise PermissionDenied(
+                {
+                    "error": (f"You tried to summon taskobject with a wrong endpoint. "
+                              f"Instead of using '{view.expected_question_model._meta.verbose_name}' endpoint, "
+                              f"try using '{request_question._meta.verbose_name}' endpoint.")
+                }
+            )

--- a/apps/questions/views/questions.py
+++ b/apps/questions/views/questions.py
@@ -6,8 +6,6 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import generics, status
 from rest_framework.response import Response
 
-from courses.mapping import ModelNameEnum
-from courses.models import TaskObject
 from progress.models import UserProfile
 from questions.mapping import TypeQuestionPoints
 from questions.serializers import (
@@ -19,6 +17,8 @@ from progress.services import check_if_answered_get
 
 from questions.models import (
     QuestionSingleAnswer,
+    QuestionConnect,
+    QuestionWrite,
     AnswerConnect,
     InfoSlide,
 )
@@ -28,6 +28,7 @@ from questions.models import (
 # а не только вопрос
 # https://www.figma.com/file/cZKZgA3ZywZykhZuHn1OQk/ProCollab?type=design&node-id=377-634&mode=design&t=Pxo1vEpfsWDnicoF-0
 from questions.serializers import InfoSlideSerializer
+from questions.permissions import CheckQuestionTypePermission
 from questions.typing import (
     QuestionSerializerData,
     SingleAnswerData,
@@ -40,6 +41,8 @@ from questions.typing import (
 
 class QuestionSingleAnswerGet(generics.ListAPIView):
     serializer_class = SingleQuestionAnswerSerializer
+    permission_classes = [CheckQuestionTypePermission]
+    expected_question_model = QuestionSingleAnswer
 
     @extend_schema(
         summary="Выводит данные для трёх видов вопросов (см. описание)",
@@ -49,22 +52,14 @@ class QuestionSingleAnswerGet(generics.ListAPIView):
         ответов (возможно пока его нет, но в будущем может появится).""",
     )
     def get(self, request, *args, **kwargs) -> Response:
-        task_object_id = self.kwargs.get("task_obj_id")
         # profile_id = UserProfile.objects.get(user_id=self.request.user.id).id
         profile_id = UserProfile.objects.get(user_id=1).id
 
-        needed_task_object = TaskObject.objects.prefetch_related(
-            "content_object",
-            "content_object__single_answers",
-            "content_object__files",
-        ).get(id=task_object_id)
-
-        question: QuestionSingleAnswer = needed_task_object.content_object
-
+        question: QuestionSingleAnswer = self.request_question
         all_answers = question.single_answers.all()
         answers = [SingleAnswerData(id=answer.id, text=answer.text) for answer in all_answers]
 
-        user_result = check_if_answered_get(task_object_id, profile_id, TypeQuestionPoints.QUESTION_SINGLE_ANSWER)
+        user_result = check_if_answered_get(self.task_object_id, profile_id, TypeQuestionPoints.QUESTION_SINGLE_ANSWER)
         correct_answer = [
             SingleAnswerData(id=all_answers.get(is_correct=True).id, text=all_answers.get(is_correct=True).text)
         ]
@@ -72,7 +67,7 @@ class QuestionSingleAnswerGet(generics.ListAPIView):
 
         serializer = self.serializer_class(
             QuestionSerializerData(
-                id=needed_task_object.id,
+                id=self.task_object_id,
                 question_text=question.text,
                 description=question.description,
                 files=[file.link for file in question.files.all()],
@@ -85,25 +80,19 @@ class QuestionSingleAnswerGet(generics.ListAPIView):
 
 class QuestionConnectGet(generics.ListAPIView):
     serializer_class = ConnectQuestionSerializer
+    permission_classes = [CheckQuestionTypePermission]
+    expected_question_model = QuestionConnect
 
     @extend_schema(
         summary="Получить данные для вопроса на соотношение",
         tags=["Вопросы и инфо-слайд"],
     )
     def get(self, request, *args, **kwargs):
-        task_object_id = self.kwargs.get("task_obj_id")
         # profile_id = UserProfile.objects.get(user_id=self.request.user.id).id
         profile_id = UserProfile.objects.get(user_id=1).id
         # TODO добавить возможность размещения файлов вместо текста справа. сделать тип вопроса
 
-        needed_task_object = TaskObject.objects.prefetch_related(
-            "content_object",
-            "content_object__connect_answers",
-            "content_object__files",
-        ).get(id=task_object_id)
-
-        question = needed_task_object.content_object
-
+        question: QuestionConnect = self.request_question
         all_connect_answers: QuerySet[AnswerConnect] = question.connect_answers.all()
 
         target_left = [
@@ -123,13 +112,15 @@ class QuestionConnectGet(generics.ListAPIView):
 
         question_data = QuestionСonnectSerializerData(
             id=question.id,
+            # Вероятно ожидается id TaskObject, если нет - удалить, если да - расскоментировать и удалить строку выше
+            # id=self.task_object_id,
             text=question.text,
             description=question.description,
             files=[file.link for file in question.files.all()],
             connect_left=target_left,
             connect_right=target_right,
         )
-        if check_if_answered_get(task_object_id, profile_id, TypeQuestionPoints.QUESTION_CONNECT):
+        if check_if_answered_get(self.task_object_id, profile_id, TypeQuestionPoints.QUESTION_CONNECT):
             question_data.is_answered = True
         else:
             random.shuffle(target_right)
@@ -141,6 +132,8 @@ class QuestionConnectGet(generics.ListAPIView):
 
 class QuestionExcludeAnswerGet(generics.ListAPIView):
     serializer_class = SingleQuestionAnswerSerializer
+    permission_classes = [CheckQuestionTypePermission]
+    expected_question_model = QuestionSingleAnswer
 
     @extend_schema(
         summary="Выводит данные для трёх видов вопросов (см. описание)",
@@ -150,30 +143,10 @@ class QuestionExcludeAnswerGet(generics.ListAPIView):
         ответов (возможно пока его нет, но в будущем может появится).""",
     )
     def get(self, request, *args, **kwargs):
-        task_object_id = self.kwargs.get("task_obj_id")
         # profile_id = UserProfile.objects.get(user_id=self.request.user.id).id
         profile_id = UserProfile.objects.get(user_id=1).id
 
-        needed_task_object = TaskObject.objects.prefetch_related(
-            "content_object",
-            "content_object__single_answers",
-            "content_object__files",
-        ).get(id=task_object_id)
-        if not isinstance(question := needed_task_object.content_object, QuestionSingleAnswer):
-            return Response(
-                {
-                    "error": f"""
-                    You tried to summon taskobject with a wrong endpoint. 
-                    Instead of using {question._meta.model_name} endpoint, 
-                    try using {ModelNameEnum.QUESTION_EXCLUDE.value} endpoint
-                    """
-                }
-            )
-        if not question.is_exclude:
-            return Response(
-                {"error": "You tried to summon question_single_answer question with question_exclude endpoint"}
-            )
-
+        question: QuestionSingleAnswer = self.request_question
         all_answers = question.single_answers.all()
         answers = [SingleAnswerData(id=answer.id, text=answer.text) for answer in all_answers]
         answers_to_exclude = [
@@ -181,13 +154,13 @@ class QuestionExcludeAnswerGet(generics.ListAPIView):
         ]
 
         data_to_serialize = QuestionSerializerData(
-            id=needed_task_object.id,
+            id=self.task_object_id,
             question_text=question.text,
             description=question.description,
             files=[file.link for file in question.files.all()],
             answers=answers,
         )
-        if check_if_answered_get(task_object_id, profile_id, TypeQuestionPoints.QUESTION_EXCLUDE):
+        if check_if_answered_get(self.task_object_id, profile_id, TypeQuestionPoints.QUESTION_EXCLUDE):
             data_to_serialize.is_answered = True
             data_to_serialize.answers = answers_to_exclude
 
@@ -199,23 +172,24 @@ class QuestionExcludeAnswerGet(generics.ListAPIView):
 
 class InfoSlideDetails(generics.ListAPIView):
     serializer_class = InfoSlideSerializer
+    permission_classes = [CheckQuestionTypePermission]
+    expected_question_model = InfoSlide
 
     @extend_schema(
         summary="Выводит информацию для информационного слайда",
         tags=["Вопросы и инфо-слайд"],
     )
     def get(self, request, *args, **kwargs):
-        task_object_id = self.kwargs.get("task_obj_id")
         user_profile_id = 1
+        info_slide: InfoSlide = self.request_question
 
-        needed_task_object = TaskObject.objects.prefetch_related("content_object").get(id=task_object_id)
-
-        info_slide: InfoSlide = needed_task_object.content_object
         serializer = self.serializer_class(
             data={
                 "text": info_slide.text,
                 "files": [file.link for file in info_slide.files.all()],
-                "is_done": bool(check_if_answered_get(task_object_id, user_profile_id, TypeQuestionPoints.INFO_SLIDE)),
+                "is_done": bool(check_if_answered_get(
+                    self.task_object_id, user_profile_id, TypeQuestionPoints.INFO_SLIDE
+                )),
             }
         )
         if serializer.is_valid():
@@ -227,24 +201,29 @@ class InfoSlideDetails(generics.ListAPIView):
 # GET вопрос для текста
 class QuestionWriteAnswer(generics.ListAPIView):
     serializer_class = WriteQuestionSerializer
+    permission_classes = [CheckQuestionTypePermission]
+    expected_question_model = QuestionWrite
 
     @extend_schema(
         summary="Выводит информацию для слайда с вопросом, для которого надо будет написать ответ",
         tags=["Вопросы и инфо-слайд"],
     )
     def get(self, request, *args, **kwargs):
-        task_object_id = self.kwargs.get("task_obj_id")
         user_profile_id = 1
+        question: QuestionWrite = self.request_question
 
-        question = TaskObject.objects.prefetch_related("content_object").get(id=task_object_id).content_object
         write_question = QuestionWriteSerializerData(
             id=question.id,
+            # Вероятно ожидается id TaskObject, если нет - удалить, если да - расскоментировать и удалить строку выше
+            # id=self.task_object_id,
             text=question.text,
             description=question.description,
             files=[file.link for file in question.files.all()],
         )
 
-        if user_answer := check_if_answered_get(task_object_id, user_profile_id, TypeQuestionPoints.QUESTION_WRITE):
+        if user_answer := check_if_answered_get(
+                self.task_object_id, user_profile_id, TypeQuestionPoints.QUESTION_WRITE
+        ):
             write_question.answer = AnswerUserWriteData(id=user_answer.id, text=user_answer.text)
 
         return Response(asdict(write_question), status=status.HTTP_200_OK)


### PR DESCRIPTION
# Обработка исключений, если запрос на получение вопроса прилетел не туда

## Описание изменений
1. Добавлен CheckQuestionTypePermission
2. Внесены правки в GET эндпоинты по получению вопроса, в соотв. с новым permission

## Дополнительная информация
Важные моменты:
1. Пожалуйста, посмотри(apps/questions/views/questions):
- QuestionConnectGet, QuestionWriteAnswer 
В данных отдается id конкретного вопроса, я это не трогал, но возможно ожидается id TaskObject, если нет, то закомментированные строки удалю.
- Просто вот тут отправляется именно id TaskObject, а не вопроса. QuestionExcludeAnswerGet QuestionSingleAnswerGet
- А вот тут вообще id не передается: InfoSlideDetails
Возможно стоит привести к общему виду

2. После добавления CheckQuestionTypePermission за ненадобностью запросы на получение TaskObject во вьюхах убраны, чтобы повторно базу не дергать, но проблема с тем, что в prefetch_related не придумал как можно было бы грамотно подтягивать content_object__%type%_answers.
