### PR TITLE
Оптимизация метода получения прогресса по навыкам пользователя

### DIFF
--- a/apps/progress/serializers.py
+++ b/apps/progress/serializers.py
@@ -17,7 +17,7 @@ class UserDataSerializer(serializers.Serializer):
 class SkillSerializer(serializers.Serializer):
     skill_name = serializers.CharField(max_length=100)
     level = serializers.IntegerField(help_text="""Выводится как 'количество пройденный уровней' + 1'""")
-    progress = serializers.FloatField(required=False, help_text="""Выводится только выбран юзером""")
+    progress = serializers.IntegerField(required=False, help_text="""Выводится только выбран юзером""")
 
 
 class MonthSerializer(serializers.Serializer):

--- a/apps/progress/typing.py
+++ b/apps/progress/typing.py
@@ -1,0 +1,2 @@
+SkillProgressType = dict[str:object]
+SkillIdType = int


### PR DESCRIPTION
# Оптимизация метода получения прогресса по навыкам пользователя

## Описание изменений
1. Количество запросов значительно сократилось, от "бесконечного", до статичных 4х (максимально упрощенных), количество не скейлится от кол-ва навыков/задач/уровней.  
2. Прогресс теперь выводится integer числом(подразумевая проценты 0-100), округление стандартное через round.  

## Дополнительная информация

Когда не выводится progress:  
- Если задач на уровне нет или решены все задачи.  

Пример response для skills:  
Навык 1: 2 уровня, 1 уровень - 3 задачи, 2 уровtнь - ничего нет:  
- не решено ничего:  
"14": {  
  "skill_name": "навык 1",  
  "level": 1,  
  "progress": 0  
}  

- решена 1 задача первого уровня:  
"14": {  
  "skill_name": "навык 1",  
  "level": 1,  
  "progress": 33  
}  

- решены все задачи первого уровня:  
"14": {  
  "skill_name": "навык 1",  
  "level": 3  
}  

progress - не выводится (все задачи решены), "level": 3 - потому что 2 уровень не содержал задач вообще, значит автоматически пройден.  

Навык 2, 1 уровень без задач вообще, но на него подписан пользователь:  
"15": {  
  "skill_name": "навык 2",  
  "level": 2  
}  
progress - не выводится (задач нет), "level": 2 - потому что 1 уровень не содержал задач вообще, значит автоматически пройден.  

