### PR TITLE
Дока теперь доступна по JWT токену

### DIFF
--- a/apps/procollab_skills/settings.py
+++ b/apps/procollab_skills/settings.py
@@ -102,6 +102,7 @@ REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_AUTHENTICATION_CLASSES": [
         # "procollab_skills.middleware.CustomJWTAuthentication",
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
         "rest_framework.authentication.BasicAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": ["procollab_skills.permissions.AuthCheck"],
@@ -199,8 +200,21 @@ SPECTACULAR_SETTINGS = {
     "REDOC_DIST": "SIDECAR",
     "SERVE_INCLUDE_SCHEMA": False,
     "COMPONENT_SPLIT_REQUEST": True,
-    "SERVE_AUTHENTICATION": ["rest_framework.authentication.SessionAuthentication"]
+    "SERVE_AUTHENTICATION": [
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework_simplejwt.authentication.JWTAuthentication"
+    ],
     # OTHER SETTINGS
+    "SECURITY_DEFINITIONS": {
+        "Bearer": {
+            "type": "http",
+            "scheme": "bearer",
+            "bearerFormat": "JWT",
+        }
+    },
+    "SWAGGER_UI_SETTINGS": {
+        "persistAuthorization": True,
+    },
 }
 
 


### PR DESCRIPTION
# Дока теперь доступна по JWT токену

1. Запрос токена /api/token/.  
2. Логиним access токен в jwtAuth  (http, Bearer).  
3. Все эндпоинты доступны.  


