### PR TITLE
Фикс бага с копированием фото с основного проколлаба

### DIFF
--- a/apps/procollab_skills/auth.py
+++ b/apps/procollab_skills/auth.py
@@ -3,10 +3,12 @@ import json
 import jwt
 import requests
 from jwt import ExpiredSignatureError, InvalidSignatureError
+from django.db import transaction
 from rest_framework import status
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.exceptions import PermissionDenied, NotAuthenticated
 
+from files.models import FileModel
 from procollab_skills import settings
 from progress.exceptions import UserDoesNotExistException
 from progress.models import UserProfile, CustomUser
@@ -30,17 +32,38 @@ class CustomAuth(TokenAuthentication):
         )
         if user_procollab_response.status_code == status.HTTP_200_OK:
             data = json.loads(user_procollab_response.content)[0]
-            user = CustomUser.objects.create(
-                email=data["email"],
-                is_superuser=data["is_superuser"],
-                first_name=data["first_name"],
-                last_name=data["last_name"],
-                password=data["password"],
-            )
+            user, user_profile = __class__._create_user_instance_from_data(data)
             view.user = user
-            view.user_profile = UserProfile.objects.get(user=user)
+            view.user_profile = user_profile
             view.profile_id = view.user_profile.id
             return user
+
+    @staticmethod
+    @transaction.atomic
+    def _create_user_instance_from_data(data) -> tuple[CustomUser, UserProfile]:
+        user: CustomUser = CustomUser.objects.create(
+            email=data["email"],
+            is_superuser=data["is_superuser"],
+            first_name=data["first_name"],
+            last_name=data["last_name"],
+            password=data["password"],
+        )
+        user_profile: UserProfile = UserProfile.objects.get(user=user)
+        url_procollab_avatar: str = data.get("avatar")
+        if url_procollab_avatar:
+            file_instanse: FileModel
+            created: bool
+            file_instanse, created = FileModel.objects.get_or_create(
+                link=url_procollab_avatar,
+                defaults={
+                    "user": user,
+                    "name": "avatar",
+                    "extension": url_procollab_avatar.split('.')[-1],
+                }
+            )
+            user_profile.file = file_instanse
+            user_profile.save()
+        return user, user_profile
 
     def authenticate(self, request) -> tuple[CustomUser, None]:
         view = request.parser_context["view"]

--- a/apps/procollab_skills/auth.py
+++ b/apps/procollab_skills/auth.py
@@ -24,15 +24,14 @@ class CustomAuth(TokenAuthentication):
             view.profile_id = view.user_profile.id
             return user
 
-    @staticmethod
-    def _check_exists_procollab(view, email: str) -> CustomUser | None:
+    def _check_exists_procollab(self, view, email: str) -> CustomUser | None:
         url_name = "dev" if settings.DEBUG else "api"
         user_procollab_response = requests.get(
             f"https://{url_name}.procollab.ru/auth/users/clone-data", data={"email": email}
         )
         if user_procollab_response.status_code == status.HTTP_200_OK:
             data = json.loads(user_procollab_response.content)[0]
-            user, user_profile = __class__._create_user_instance_from_data(data)
+            user, user_profile = self._create_user_instance_from_data(data)
             view.user = user
             view.user_profile = user_profile
             view.profile_id = view.user_profile.id
@@ -51,15 +50,13 @@ class CustomAuth(TokenAuthentication):
         user_profile: UserProfile = UserProfile.objects.get(user=user)
         url_procollab_avatar: str = data.get("avatar")
         if url_procollab_avatar:
-            file_instanse: FileModel
-            created: bool
-            file_instanse, created = FileModel.objects.get_or_create(
+            file_instanse, if_created = FileModel.objects.get_or_create(
                 link=url_procollab_avatar,
                 defaults={
                     "user": user,
                     "name": "avatar",
-                    "extension": url_procollab_avatar.split('.')[-1],
-                }
+                    "extension": url_procollab_avatar.split(".")[-1],
+                },
             )
             user_profile.file = file_instanse
             user_profile.save()


### PR DESCRIPTION
# Фикс бага с копированием фото с основного проколлаба

1. Фото теперь копируется.
2. Поправил реализацию, вынес в отдельный метод под транзакцию создание пользователя(сигналом его профиля) и объекта File для профиля.

## Проверка кода
Локально взял SECRET_KEY дева, сгенерил себе токен с дева основы проколлаба, прокинул запрос на профиль с токеном локально. Пользователь локально создался корректно, фото подтянулось.

## Дополнительная информация
На что можно обратить внимание:
response по профилю вместо логичного "avatar" оставил как было "file_link".




